### PR TITLE
修复谷歌浏览器被识别为360EE的问题

### DIFF
--- a/src/module/browser/360EE.js
+++ b/src/module/browser/360EE.js
@@ -10,7 +10,7 @@ export default {
         if(getMime('type','application/cenroll.cenroll.version.1')||getMime('type','application/hwepass2001.installepass2001')){
             isMatch = true;
         }else if(_360.match(ua)){
-            if(_globalThis?.navigator?.userAgentData?.brands.find(item=>item.brand=='Not A(Brand'||item.brand=='Not?A_Brand')){
+            if(_globalThis?.navigator?.userAgentData?.brands.find(item=>item.brand=='Not?A_Brand')){
                 isMatch = true;
             }
         }


### PR DESCRIPTION
最新版本的谷歌浏览器brands包含Not/A)Brand，无法根据这个判断是否是360EE
![image](https://github.com/user-attachments/assets/fe3c784f-3dcd-49bc-88e9-4842740528b0)
目前使用的谷歌浏览器

![image](https://github.com/user-attachments/assets/75232ea5-b884-458a-8fa4-c2560942a184)
